### PR TITLE
Simple array roundtrip

### DIFF
--- a/src/babel/python.cpp
+++ b/src/babel/python.cpp
@@ -2,6 +2,8 @@
 #include <pybind11/stl.h>
 #include <Python.h>
 
+#include <iostream>
+
 #include <arrow/python/pyarrow.h>
 #include <arrow/array/builder_primitive.h>
 
@@ -9,11 +11,16 @@ namespace py = pybind11;
 using DoubleArray = arrow::DoubleArray;
 using Array = arrow::Array;
 
-double sum(PyObject* source) {
-    if(!arrow::py::is_array(source))
-        return false;
 
-    arrow::Result<std::shared_ptr<arrow::Array>> result = arrow::py::unwrap_array(source);
+double sum(py::handle& source) {
+    PyObject* src = source.ptr();
+
+    if(!arrow::py::is_array(src)){
+        std::cout << "not an array" << std::endl;
+        return false;
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Array>> result = arrow::py::unwrap_array(src);
     if(!result.ok())
         return false;
 
@@ -25,23 +32,6 @@ double sum(PyObject* source) {
     }
     return sum;
 }
-/*
-double sum(std::shared_ptr<arrow::DoubleArray> a) {
-    double sum = 0;
-    for(int i = 0; i < a->length(); i++) {
-        sum += a->Value(i);
-    }
-    return sum;
-}
-*/
-
-// for arrow, try something like
-/*
-
-   std::shared_ptr<arrow::Buffer> arbitrary_buffer = ... ;
-std::shared_ptr<arrow::Buffer> cpu_buffer = arrow::Buffer::ViewOrCopy(
-   arbitrary_buffer, arrow::default_cpu_memory_manager());
-*/
 
 PYBIND11_MODULE(babel, m) {
   // Ensure dependencies are loaded.

--- a/src/babel/python.cpp
+++ b/src/babel/python.cpp
@@ -6,6 +6,7 @@
 
 #include <arrow/python/pyarrow.h>
 #include <arrow/array/builder_primitive.h>
+#include <arrow/compute/function.h>
 
 namespace py = pybind11;
 using DoubleArray = arrow::DoubleArray;
@@ -33,9 +34,49 @@ double sum(py::handle& source) {
     return sum;
 }
 
+py::handle times_two(py::handle& source) {
+    PyObject* src = source.ptr();
+
+    if(!arrow::py::is_array(src)){
+        std::cout << "not an array" << std::endl;
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Array>> result = arrow::py::unwrap_array(src);
+    if(!result.ok()){
+        std::cout << "not ok" << std::endl;
+
+    }
+
+    std::shared_ptr<arrow::DoubleArray> a = std::static_pointer_cast<arrow::DoubleArray>(result.ValueOrDie());
+    std::cout << "a: " << a << std::endl;
+    std::cout << "a: " << a->values()->data() << std::endl;
+    std::cout << "a: " << a->ToString() << std::endl;
+
+
+    arrow::DoubleBuilder builder;
+    builder.Resize(3);
+
+    std::vector<bool> validity = {true, true, true};
+    std::vector<double> values = {3.1, 4.2 ,5.3};
+
+    builder.AppendValues(values, validity);
+    
+    std::shared_ptr<arrow::Array> array;
+    arrow::Status st = builder.Finish(&array);
+
+    if(!st.ok()){
+        std::cout << "not ok" << std::endl;
+    }
+
+    return arrow::py::wrap_array(array);
+}
+
+
+
 PYBIND11_MODULE(babel, m) {
   // Ensure dependencies are loaded.
   arrow::py::import_pyarrow();
 
   m.def("sum", &sum, py::call_guard<py::gil_scoped_release>());
+  m.def("times_two", &times_two);
 }

--- a/test-python.py
+++ b/test-python.py
@@ -17,7 +17,12 @@ import numpy as np
 
 import build.babel
 
-# def test_sum():
-#     x = pa.array([1,2,3.1])
-#     assert build.babel.sum(x) == np.sum(np.array(x))
-#     assert build.babel.sum(x[1:]) == np.sum(np.array(x[1:]))
+def test_sum():
+    data = [1,2,3.1]
+    x = pa.array(data)
+    assert build.babel.sum(x) == np.sum(np.array(data))
+    assert build.babel.sum(x[1:]) == np.sum(np.array(x[1:]))
+
+
+if __name__ == '__main__':
+    test_sum()

--- a/test-python.py
+++ b/test-python.py
@@ -32,6 +32,12 @@ def test_awkward_roundtrip():
     out_arr = ak.from_arrow(out_arrow)
     assert ak.to_numpy(out_arr).tolist() ==  [3.1, 4.2, 5.3]  
 
+def test_struct():
+    s = build.babel.handle_struct()
+    a = ak.from_arrow(s)
+    assert str(ak.type(a)) == '3 * {"pt": ?float64, "eta": ?float64}'
+
 if __name__ == '__main__':
     test_sum()
     test_awkward_roundtrip()
+    test_struct()

--- a/test-python.py
+++ b/test-python.py
@@ -14,6 +14,7 @@ def test_producer():
 
 import pyarrow as pa
 import numpy as np
+import awkward as ak
 
 import build.babel
 
@@ -24,5 +25,13 @@ def test_sum():
     assert build.babel.sum(x[1:]) == np.sum(np.array(x[1:]))
 
 
+def test_awkward_roundtrip():
+    in_arr = ak.Array([1.,2.,3.])
+    in_arrow = ak.to_arrow(in_arr)
+    out_arrow = build.babel.times_two(in_arrow)
+    out_arr = ak.from_arrow(out_arrow)
+    assert ak.to_numpy(out_arr).tolist() ==  [3.1, 4.2, 5.3]  
+
 if __name__ == '__main__':
     test_sum()
+    test_awkward_roundtrip()


### PR DESCRIPTION
this adds a simple round trip array -> array 

the array being returned is just hard-coded for now, but thtis means we only need to figure out how to do 

`arrow::Array -> arrow::Arrary` functions in C++, the python binding should be clear now